### PR TITLE
make numerical operators nil-safe

### DIFF
--- a/src/where/operation.cljc
+++ b/src/where/operation.cljc
@@ -257,8 +257,8 @@
     (let [low (min v1 v2)
           high (max v1 v2)]
       (fn [item]
-        (when item
-          (<= low (extractor item) high))))
+        (when-let [i (extractor item)]
+          (<= low i high))))
     (constantly nil)))
 
 
@@ -269,8 +269,8 @@
     (let [low (min v1 v2)
           high (max v1 v2)]
       (fn [item]
-        (when item
-          (< low (extractor item) high))))
+        (when-let [i (extractor item)]
+          (< low i high))))
     (constantly nil)))
 
 
@@ -281,6 +281,6 @@
     (let [low (min v1 v2)
           high (max v1 v2)]
       (fn [item]
-        (when item
-          (or (= low (extractor item)) (< low (extractor item) high)))))
+        (when-let [i (extractor item)]
+          (or (= low i) (< low i high)))))
     (constantly nil)))


### PR DESCRIPTION
Hi
I'm getting NullPointerExceptions with the following comparators. The readme states they should be nil safe but they don't appear to be. When there is no value for the extractor, an NPE is thrown.
```
(filter (where :a :between? [1 2]) [{:b 2} {:c 3}])
(filter (where :a :strictly-between? [1 2]) [{:b 2} {:c 3}])
(filter (where :a :range? [1 2]) [{:b 2} {:c 3}])
```
This PR should fix this. I can add test cases if you'd like.

Thanks!